### PR TITLE
Broadcastmonkey/address node name validation

### DIFF
--- a/GolemUI.csproj
+++ b/GolemUI.csproj
@@ -543,7 +543,15 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="UI\Themes\TextBox\TextBoxInError.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="UI\Themes\TrackBar\Slider.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="UI\Themes\Validation\ValidationTemplate.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/UI/DashboardSettings.xaml
+++ b/UI/DashboardSettings.xaml
@@ -30,6 +30,8 @@
                 <ResourceDictionary Source="Icons/CPU_icon.xaml"/>
                 <ResourceDictionary Source="Icons/Status_Card_error.xaml"/>
                 <ResourceDictionary Source="Icons/Status_Ready_icon.xaml"/>
+                <ResourceDictionary Source="Themes/TextBox/TextBoxInError.xaml"/>
+                <ResourceDictionary Source="Themes/Validation/ValidationTemplate.xaml"/>
                 <ResourceDictionary>
                     <ObjectDataProvider x:Key="dataFromEnum" MethodName="GetValues" ObjectType="{x:Type System:Enum}">
                         <ObjectDataProvider.MethodParameters>
@@ -227,7 +229,15 @@
                                 <RowDefinition Height="40"/>
                             </Grid.RowDefinitions>
                             <Label Margin="5,5,0,0" Content="Node name" FontFamily="Segoe UI" FontWeight="Bold" HorizontalAlignment="Left" Grid.Column="0" Grid.Row="0" Foreground="#FFFFFF"/>
-                            <TextBox BorderThickness="0,0,0,2" Grid.Row="1" VerticalAlignment="Top" Background="Transparent" Foreground="#eee" CaretBrush="#fff" Text="{Binding NodeName}" Margin="20, 0"/>
+                            <TextBox Style="{StaticResource TextBoxInError}" Validation.ErrorTemplate="{StaticResource ValidationTemplate}" BorderThickness="0,0,0,2" Grid.Row="1" VerticalAlignment="Top" Background="Transparent" Foreground="#eee" CaretBrush="#fff" Margin="20, 0">
+                                <TextBox.Text>
+                                    <Binding Path="NodeName" UpdateSourceTrigger="PropertyChanged" Delay="100">
+                                        <Binding.ValidationRules>
+                                            <lc:NodeNameValidator xmlns:lc="clr-namespace:GolemUI.Validators"/>
+                                        </Binding.ValidationRules>
+                                    </Binding>
+                                </TextBox.Text>
+                            </TextBox>
                         </Grid>
                     </Border>
                 </Grid>

--- a/UI/DlgEditAddress.xaml
+++ b/UI/DlgEditAddress.xaml
@@ -58,7 +58,7 @@
                     <TextBox.Text>
                         <Binding Path="Address" UpdateSourceTrigger="PropertyChanged">
                             <Binding.ValidationRules>
-                                <lc:EthAddrValidator/>
+                                <lc:EthAddrValidator ShouldCheckForChecksum="False"/>
                             </Binding.ValidationRules>
                         </Binding>
                     </TextBox.Text>

--- a/UI/SetupWindow.xaml
+++ b/UI/SetupWindow.xaml
@@ -43,7 +43,7 @@
                 <ResourceDictionary>
                     <DataTemplate x:Key="DTGPU">
                         <StackPanel Margin="1" MaxWidth="250" ToolTip="{Binding Path=GPUError}">
-                            <TextBlock Text="{Binding gpuName}" Foreground="#aaa" TextWrapping="WrapWithOverflow"/>
+                            <TextBlock Text="{Binding GpuName}" Foreground="#aaa" TextWrapping="WrapWithOverflow"/>
                             <TextBlock Text="{Binding Path=BenchmarkSpeed, Converter={StaticResource HashRateConverter}}"></TextBlock>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                                 <TextBlock Text="Mining ablity " Foreground="#aaa" Margin="0, 5" />

--- a/UI/SetupWindow.xaml
+++ b/UI/SetupWindow.xaml
@@ -401,7 +401,7 @@ They are a backup for your wallet and in case your disk fails or any other unexp
                                                     </Binding>
                                                 </TextBox.Text>
                                             </TextBox>
-                                            <Label Margin="20,-20,0,0" FontSize="10" FontFamily="Segoe UI" Foreground="White" Content="(Use numbers, latin characters, dash '-', space '  ' and underscore '__'. Node name must have at least 3 characters)" >
+                                            <Label Margin="20,-20,0,0" FontSize="10" FontFamily="Segoe UI" Foreground="White" Content="(Use numbers, latin characters, dash '-', space '  ' and underscore '__'. Node name must have at least 3 characters and start with underscore, digit or latin alphabet character))" >
                                                 <Label.Style>
                                                     <Style TargetType="{x:Type Label}">
                                                         <Setter Property="Visibility" Value="Visible" />
@@ -599,7 +599,7 @@ They are a backup for your wallet and in case your disk fails or any other unexp
                                                 <TextBox.Text>
                                                     <Binding Path="Address" UpdateSourceTrigger="PropertyChanged">
                                                         <Binding.ValidationRules>
-                                                            <lc:EthAddrValidator xmlns:lc="clr-namespace:GolemUI.Validators"/>
+                                                            <lc:EthAddrValidator xmlns:lc="clr-namespace:GolemUI.Validators" ShouldCheckForChecksum="True"/>
                                                         </Binding.ValidationRules>
                                                     </Binding>
                                                 </TextBox.Text>
@@ -649,7 +649,7 @@ They are a backup for your wallet and in case your disk fails or any other unexp
                                                     </Binding>
                                                 </TextBox.Text>
                                             </TextBox>
-                                            <Label FontSize="10" FontFamily="Segoe UI" Foreground="White" Content="(Use numbers, latin characters, dash '-', space '  ' and underscore '__'. Node name must have at least 3 characters)">
+                                            <Label FontSize="10" FontFamily="Segoe UI" Foreground="White" Content="(Use numbers, latin characters, dash '-', space '  ' and underscore '__'. Node name must have at least 3 characters and start with underscore, digit or latin alphabet character)">
                                                 <Label.Style>
                                                     <Style TargetType="{x:Type Label}">
                                                         <Setter Property="Visibility" Value="Visible" />

--- a/UI/SetupWindow.xaml
+++ b/UI/SetupWindow.xaml
@@ -698,10 +698,10 @@ They are a backup for your wallet and in case your disk fails or any other unexp
                                             
                                         </Grid.RowDefinitions>
                                         <ContentControl VerticalAlignment="Top" Content="{DynamicResource Benchmark_Step_icon}" Margin="6,20,0,0"/>
-                                        <StackPanel MinWidth="400" Margin="20,50" Grid.Column="1" HorizontalAlignment="Stretch">
-                                            <TextBlock FontFamily="Segoe UI" FontSize="18" FontWeight="Bold" Margin="20, 0, 0 15">Calculating your hash power</TextBlock>
+                                        <StackPanel MinWidth="400" Margin="10,20,0,0" Grid.Column="1" HorizontalAlignment="Stretch">
+                                            <TextBlock FontFamily="Segoe UI" FontSize="18" FontWeight="Bold" Margin="5, 0, 0 15">Calculating your hash power</TextBlock>
                                             <UniformGrid Rows="1" Columns="2">
-                                                <ListBox Background="Transparent" Margin="10" ItemsSource="{Binding GPUs}" Foreground="#eee" BorderThickness="0" ItemTemplate="{StaticResource DTGPU}">
+                                                <ListBox Background="Transparent" Margin="0,10" ItemsSource="{Binding GPUs}" Foreground="#eee" BorderThickness="0" ItemTemplate="{StaticResource DTGPU}">
                                                     <ListBox.ItemsPanel>
                                                         <ItemsPanelTemplate>
                                                             <UniformGrid Columns="1"/>
@@ -734,10 +734,10 @@ They are a backup for your wallet and in case your disk fails or any other unexp
                                         
                                         </Grid.RowDefinitions>
                                         <ContentControl Content="{DynamicResource Enjoy_Step_icon}" Margin="6,20,0,0" VerticalAlignment="Top"/>
-                                        <StackPanel MinWidth="400" Margin="20,50" Grid.Column="1" HorizontalAlignment="Stretch">
+                                        <StackPanel MinWidth="400" Margin="20,20,0,0" Grid.Column="1" HorizontalAlignment="Stretch">
                                             <TextBlock FontFamily="Segoe UI" FontSize="18" FontWeight="Bold" Margin="20, 0, 0 15">Enjoy!</TextBlock>
                                             <Label Grid.Column="1" Content="{Binding BenchmarkError}" Margin="20, 0, 0 15"></Label>
-                                            <UniformGrid Rows="1" Columns="2">
+                                            <UniformGrid Rows="1" Columns="2" Margin="0">
                                                 <ListBox Background="Transparent" Margin="10" ItemsSource="{Binding GPUs}" Foreground="#eee" BorderThickness="0" ItemTemplate="{StaticResource DTGPU}">
                                                     <ListBox.ItemsPanel>
                                                         <ItemsPanelTemplate>

--- a/UI/SetupWindow.xaml
+++ b/UI/SetupWindow.xaml
@@ -38,6 +38,8 @@
                 <ResourceDictionary Source="Icons/Wallet_Icon.xaml"/>
                 <ResourceDictionary Source="Icons/Status_Card_error.xaml"/>
                 <ResourceDictionary Source="Icons/Status_Ready_icon.xaml"/>
+                <ResourceDictionary Source="Themes/TextBox/TextBoxInError.xaml"/>
+                <ResourceDictionary Source="Themes/Validation/ValidationTemplate.xaml"/>
                 <ResourceDictionary>
                     <DataTemplate x:Key="DTGPU">
                         <StackPanel Margin="1" MaxWidth="250" ToolTip="{Binding Path=GPUError}">
@@ -151,24 +153,6 @@
                             </StackPanel>
                         </StackPanel>
                     </DataTemplate>
-                    <ControlTemplate x:Key="ValidationTemplate">
-                        <DockPanel>
-                            <TextBlock Foreground="Red" FontSize="16" Margin="4" FontFamily="Segoe UI Black">!</TextBlock>
-                            <AdornedElementPlaceholder/>
-                        </DockPanel>
-                    </ControlTemplate>
-                    <Style x:Key="TextBoxInError" TargetType="{x:Type TextBox}">
-                        <Style.Triggers>
-                            <Trigger Property="Validation.HasError" Value="true">
-                                <Setter Property="ToolTip"
-              Value="{Binding RelativeSource={x:Static RelativeSource.Self},
-                              Path=(Validation.Errors)[0].ErrorContent}"/>
-                                <Setter Property="Background" Value="#faa"/>
-                                <Setter Property="BorderBrush" Value="#faa"/>
-                                <Setter Property="BorderThickness" Value="1"/>
-                            </Trigger>
-                        </Style.Triggers>
-                    </Style>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -599,7 +583,7 @@ They are a backup for your wallet and in case your disk fails or any other unexp
                                                 <TextBox.Text>
                                                     <Binding Path="Address" UpdateSourceTrigger="PropertyChanged">
                                                         <Binding.ValidationRules>
-                                                            <lc:EthAddrValidator xmlns:lc="clr-namespace:GolemUI.Validators" ShouldCheckForChecksum="True"/>
+                                                            <lc:EthAddrValidator xmlns:lc="clr-namespace:GolemUI.Validators" ShouldCheckForChecksum="False"/>
                                                         </Binding.ValidationRules>
                                                     </Binding>
                                                 </TextBox.Text>

--- a/UI/Themes/TextBox/TextBoxInError.xaml
+++ b/UI/Themes/TextBox/TextBoxInError.xaml
@@ -1,0 +1,18 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                     xmlns:local="clr-namespace:GolemUI">
+
+    <Style x:Key="TextBoxInError" TargetType="{x:Type TextBox}">
+        <Style.Triggers>
+            <Trigger Property="Validation.HasError" Value="true">
+                <Setter Property="ToolTip"
+              Value="{Binding RelativeSource={x:Static RelativeSource.Self},
+                              Path=(Validation.Errors)[0].ErrorContent}"/>
+                <Setter Property="Background" Value="#faa"/>
+                <Setter Property="BorderBrush" Value="#faa"/>
+                <Setter Property="BorderThickness" Value="1"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+</ResourceDictionary>

--- a/UI/Themes/Validation/ValidationTemplate.xaml
+++ b/UI/Themes/Validation/ValidationTemplate.xaml
@@ -1,0 +1,11 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                     xmlns:local="clr-namespace:GolemUI">
+
+    <ControlTemplate x:Key="ValidationTemplate">
+        <DockPanel>
+            <TextBlock Foreground="Red" FontSize="16" Margin="4" FontFamily="Segoe UI Black">!</TextBlock>
+            <AdornedElementPlaceholder/>
+        </DockPanel>
+    </ControlTemplate>
+</ResourceDictionary>

--- a/Validators/EthAddrValidator.cs
+++ b/Validators/EthAddrValidator.cs
@@ -6,12 +6,13 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Controls;
+using Nethereum.Util;
 
 namespace GolemUI.Validators
 {
     public class EthAddrValidator : ValidationRule
     {
-        public bool ForceChecksum { get; set; }
+        public bool ShouldCheckForChecksum { get; set; }
         public override ValidationResult Validate(object value, CultureInfo cultureInfo)
         {
             var text = value as string;
@@ -25,16 +26,22 @@ namespace GolemUI.Validators
                 return new ValidationResult(false, "invalid address, it should be 20 byte hexencoded number with 0x prefix");
             }
 
-            if (!ForceChecksum)
+            if (!ShouldCheckForChecksum)
             {
                 if (text == text.ToLower() || text == text.ToUpper())
                 {
                     return ValidationResult.ValidResult;
                 }
             }
-            // TODO checksum check
-            return ValidationResult.ValidResult;
 
+            if(new AddressUtil().IsChecksumAddress(text))
+            {
+                return ValidationResult.ValidResult;
+            }
+            else
+            {
+                return new ValidationResult(false, "invalid address, checksum does not match expected value");
+            }
         }
     }
 }

--- a/Validators/EthAddrValidator.cs
+++ b/Validators/EthAddrValidator.cs
@@ -34,7 +34,7 @@ namespace GolemUI.Validators
                 }
             }
 
-            if(new AddressUtil().IsChecksumAddress(text))
+            if (new AddressUtil().IsChecksumAddress(text))
             {
                 return ValidationResult.ValidResult;
             }

--- a/Validators/EthAddrValidator.cs
+++ b/Validators/EthAddrValidator.cs
@@ -26,22 +26,25 @@ namespace GolemUI.Validators
                 return new ValidationResult(false, "invalid address, it should be 20 byte hexencoded number with 0x prefix");
             }
 
-            if (!ShouldCheckForChecksum)
+            /*if (!ShouldCheckForChecksum)
             {
                 if (text == text.ToLower() || text == text.ToUpper())
                 {
                     return ValidationResult.ValidResult;
                 }
-            }
-
-            if (new AddressUtil().IsChecksumAddress(text))
+            }*/
+            if (ShouldCheckForChecksum)
             {
-                return ValidationResult.ValidResult;
+                if (new AddressUtil().IsChecksumAddress(text))
+                {
+                    return ValidationResult.ValidResult;
+                }
+                else
+                {
+                    return new ValidationResult(false, "invalid address, checksum does not match expected value");
+                }
             }
-            else
-            {
-                return new ValidationResult(false, "invalid address, checksum does not match expected value");
-            }
+            return ValidationResult.ValidResult;
         }
     }
 }

--- a/Validators/NodeNameValidator.cs
+++ b/Validators/NodeNameValidator.cs
@@ -27,7 +27,7 @@ namespace GolemUI.Validators
             {
                 return new ValidationResult(false, "wrong characters, use only alphanumeric characters, ' ', '-' and '_' name must start witch letter, underscore or digit");
             }
-            
+
             return ValidationResult.ValidResult;
         }
     }

--- a/Validators/NodeNameValidator.cs
+++ b/Validators/NodeNameValidator.cs
@@ -22,11 +22,12 @@ namespace GolemUI.Validators
             {
                 return new ValidationResult(false, "Node Name must have at least 3 characters");
             }
-            var reNodeName = new Regex(@"^[a-zA-Z\d-_ ]+$");
+            var reNodeName = new Regex(@"^[a-zA-Z0-9_]+[a-zA-Z\d-_ ]+$");
             if (!reNodeName.Match(text).Success)
             {
-                return new ValidationResult(false, "wrong characters, use only alphanumeric characters, ' ', '-' and '_' ");
+                return new ValidationResult(false, "wrong characters, use only alphanumeric characters, ' ', '-' and '_' name must start witch letter, underscore or digit");
             }
+            
             return ValidationResult.ValidResult;
         }
     }

--- a/ViewModel/EditAddressViewModel.cs
+++ b/ViewModel/EditAddressViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Nethereum.Util;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -35,7 +36,7 @@ namespace GolemUI.ViewModel
 
         public EditAddressViewModel(Interfaces.IPaymentService paymentService)
         {
-            _address = paymentService.Address;
+            _address = new AddressUtil().ConvertToChecksumAddress(paymentService.Address); // one time conversion while loading model
             InternalAddress = paymentService.InternalAddress;
             HaveInternalBalance = paymentService.State?.Balance > 0;
         }

--- a/ViewModel/SetupViewModel.cs
+++ b/ViewModel/SetupViewModel.cs
@@ -2,6 +2,7 @@
 using GolemUI.Interfaces;
 using GolemUI.Validators;
 using NBitcoin;
+using Nethereum.Util;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -163,7 +164,7 @@ namespace GolemUI.ViewModel
 
         public string? Address
         {
-            get => _providerConfig?.Config?.Account;
+            get => new AddressUtil().ConvertToChecksumAddress(_providerConfig?.Config?.Account);
             set
             {
                 _providerConfig?.UpdateWalletAddress(value);

--- a/ViewModel/SetupViewModel.cs
+++ b/ViewModel/SetupViewModel.cs
@@ -1,10 +1,12 @@
 ﻿using GolemUI.Claymore;
 using GolemUI.Interfaces;
+using GolemUI.Validators;
 using NBitcoin;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -17,6 +19,7 @@ namespace GolemUI.ViewModel
         private readonly Src.BenchmarkService _benchmarkService;
         private readonly Interfaces.IEstimatedProfitProvider _profitEstimator;
         private readonly IProcessControler _processControler;
+        private NodeNameValidator NodeNameValidator = new NodeNameValidator();
 
         public enum FlowSteps
         {
@@ -221,7 +224,8 @@ namespace GolemUI.ViewModel
             get => _providerConfig.Config?.NodeName;
             set
             {
-                _providerConfig.UpdateNodeName(value);
+                if(NodeNameValidator.Validate(value, CultureInfo.InvariantCulture)?.IsValid ?? false)
+                    _providerConfig.UpdateNodeName(value);
             }
         }
 

--- a/ViewModel/SetupViewModel.cs
+++ b/ViewModel/SetupViewModel.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -19,7 +18,7 @@ namespace GolemUI.ViewModel
         private readonly Src.BenchmarkService _benchmarkService;
         private readonly Interfaces.IEstimatedProfitProvider _profitEstimator;
         private readonly IProcessControler _processControler;
-        private NodeNameValidator NodeNameValidator = new NodeNameValidator();
+
 
         public enum FlowSteps
         {
@@ -224,8 +223,7 @@ namespace GolemUI.ViewModel
             get => _providerConfig.Config?.NodeName;
             set
             {
-                if(NodeNameValidator.Validate(value, CultureInfo.InvariantCulture)?.IsValid ?? false)
-                    _providerConfig.UpdateNodeName(value);
+                _providerConfig.UpdateNodeName(value);
             }
         }
 

--- a/ViewModel/WalletViewModel.cs
+++ b/ViewModel/WalletViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using GolemUI.Command;
 using GolemUI.Interfaces;
 using GolemUI.Model;
+using Nethereum.Util;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -91,7 +92,7 @@ namespace GolemUI.ViewModel
             }
         }
 
-        public string? WalletAddress => _paymentService.Address;
+        public string? WalletAddress => new AddressUtil().ConvertToChecksumAddress(_paymentService.Address);
 
         public decimal Amount
         {


### PR DESCRIPTION
- setup window / wallet address validation status now triggers IsEnabled property of 'next' Button
- setup window / node name validation status now triggers IsEnabled property of 'next' Button
- setup window - wallet address getter now returns ETH address with checksum encoded in character (lower/upper) casing
- wallet settings - wallet address is transformed into wallet address with checksum in EditDlg constructor now returns ETH address with checksum encoded in character (lower/upper) casing
- fixed xaml binding for GPU name in setup window