### PR TITLE
Apply new validation rules

### DIFF
--- a/UI/DashboardSettings.xaml
+++ b/UI/DashboardSettings.xaml
@@ -233,7 +233,7 @@
                                 <TextBox.Text>
                                     <Binding Path="NodeName" UpdateSourceTrigger="PropertyChanged" Delay="100">
                                         <Binding.ValidationRules>
-                                            <lc:NodeNameValidator xmlns:lc="clr-namespace:GolemUI.Validators"/>
+                                            <lc:NodeNameValidator xmlns:lc="clr-namespace:GolemUI.Validators"  ValidatesOnTargetUpdated="True"/>
                                         </Binding.ValidationRules>
                                     </Binding>
                                 </TextBox.Text>

--- a/UI/SetupWindow.xaml
+++ b/UI/SetupWindow.xaml
@@ -380,7 +380,7 @@ They are a backup for your wallet and in case your disk fails or any other unexp
                                                 <TextBox.Text>
                                                     <Binding Path="NodeName" UpdateSourceTrigger="PropertyChanged" Delay="100">
                                                         <Binding.ValidationRules>
-                                                            <lc:NodeNameValidator xmlns:lc="clr-namespace:GolemUI.Validators"/>
+                                                            <lc:NodeNameValidator xmlns:lc="clr-namespace:GolemUI.Validators"  ValidatesOnTargetUpdated="True"/>
                                                         </Binding.ValidationRules>  
                                                     </Binding>
                                                 </TextBox.Text>
@@ -581,9 +581,9 @@ They are a backup for your wallet and in case your disk fails or any other unexp
                                  Margin="0,10,0,0" Padding="2" BorderThickness="0,0,0,2" Background="Transparent" Foreground="#eee" CaretBrush="#fff"
                                  Validation.ErrorTemplate="{StaticResource ValidationTemplate}" Style="{StaticResource TextBoxInError}">
                                                 <TextBox.Text>
-                                                    <Binding Path="Address" UpdateSourceTrigger="PropertyChanged">
+                                                    <Binding Path="Address" UpdateSourceTrigger="PropertyChanged" >
                                                         <Binding.ValidationRules>
-                                                            <lc:EthAddrValidator xmlns:lc="clr-namespace:GolemUI.Validators" ShouldCheckForChecksum="False"/>
+                                                            <lc:EthAddrValidator xmlns:lc="clr-namespace:GolemUI.Validators" ShouldCheckForChecksum="False" ValidatesOnTargetUpdated="True"/>
                                                         </Binding.ValidationRules>
                                                     </Binding>
                                                 </TextBox.Text>
@@ -628,7 +628,7 @@ They are a backup for your wallet and in case your disk fails or any other unexp
                                                 <TextBox.Text>
                                                     <Binding Path="NodeName" UpdateSourceTrigger="PropertyChanged" Delay="100">
                                                         <Binding.ValidationRules>
-                                                            <lc:NodeNameValidator xmlns:lc="clr-namespace:GolemUI.Validators"/>
+                                                            <lc:NodeNameValidator xmlns:lc="clr-namespace:GolemUI.Validators"  ValidatesOnTargetUpdated="True"/>
                                                         </Binding.ValidationRules>
                                                     </Binding>
                                                 </TextBox.Text>

--- a/Validators/EthAddrValidator.cs
+++ b/Validators/EthAddrValidator.cs
@@ -18,7 +18,7 @@ namespace GolemUI.Validators
             var text = value as string;
             if (text == null)
             {
-                return ValidationResult.ValidResult;
+                return new ValidationResult(false, "Address can't be null");
             }
             var reBasicAddress = new Regex("^0x[0-9a-f]{40}$", RegexOptions.IgnoreCase);
             if (!reBasicAddress.Match(text).Success)


### PR DESCRIPTION
Validation is now triggered when control is loaded.

Before:
When address was null or empty (default) at the beginning in pro user setup window validation was not triggered and user could go to next step with empty address.

Same goes to Node Name.

Now:
Validation is also triggered when control is loaded.