### PR TITLE
turning mining off when gpu is disabled

### DIFF
--- a/Src/ProviderConfigService.cs
+++ b/Src/ProviderConfigService.cs
@@ -131,8 +131,8 @@ namespace GolemUI.Src
                         { "hash-rate", 0m }
                     }), out _args, out _info);
 
-                        _provider.ActivatePreset("gminer");
-                        changedProperties.Add("IsMiningActive");
+                        /* _provider.ActivatePreset("gminer");
+                         changedProperties.Add("IsMiningActive");*/
                     }
                     else
                     {
@@ -152,8 +152,8 @@ namespace GolemUI.Src
                         { "cpu", 0.001m },
                         { "duration", 0m }
                     }), out _args, out _info);
-                    _provider.ActivatePreset("wasmtime");
-                    changedProperties.Add("IsCpuActive");
+                    /*_provider.ActivatePreset("wasmtime");
+                     changedProperties.Add("IsCpuActive");*/
                 }
 
                 if (presets.Contains("default"))

--- a/UI/DashboardSettings.xaml
+++ b/UI/DashboardSettings.xaml
@@ -93,7 +93,7 @@
                 </StackPanel>
 
 
-                <Button Margin="0,0,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Top"   Grid.Column="4" IsEnabled="{Binding Path=BenchmarkReadyToRun}" Visibility="{Binding Path=BenchmarkReadyToRun, Converter={StaticResource BoolToVisibleConverter}}"  Name="btnRunBenchmark" Style="{StaticResource GradientButtonStyle}"  Click="btnRunBenchmark_Click" >Run Benchmark</Button>
+                <Button Margin="0,0,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Top"   Grid.Column="4" IsEnabled="{Binding Path=BenchmarkReadyToRun}" Visibility="{Binding Path=IsBenchmarkNotRunning, Converter={StaticResource BoolToVisibleConverter}}"  Name="btnRunBenchmark" Style="{StaticResource GradientButtonStyle}"  Click="btnRunBenchmark_Click" >Run Benchmark</Button>
                 <Button Margin="0,0,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Top"   Grid.Column="4" IsEnabled="{Binding Path=BenchmarkIsRunning}" Visibility="{Binding Path=BenchmarkIsRunning, Converter={StaticResource BoolToVisibleConverter}}" Name="btnStopBenchmark" Style="{StaticResource GradientButtonStyle}" Click="btnStopBenchmark_Click" >Stop Benchmark</Button>
 
 
@@ -118,11 +118,11 @@
                         <Image RenderOptions.BitmapScalingMode="HighQuality"  Source="/UI/Icons/DefaultStyle/png/Settings/TaskType.png" Grid.Row="1" HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="20" Stretch="Uniform" />
                         <StackPanel Grid.Row="2" Margin="0,28,0,0" HorizontalAlignment="Center">
                             <StackPanel Orientation="Horizontal">
-                                <CheckBox  Margin="0" Grid.Column="0" Style="{DynamicResource CheckBoxSlider}" IsChecked="{Binding IsMiningActive}" IsEnabled="{Binding BenchmarkReadyToRun}" />
+                                <CheckBox  Margin="0" Grid.Column="0" Style="{DynamicResource CheckBoxSlider}" IsChecked="{Binding IsGpuEnabled}" IsEnabled="{Binding IsBenchmarkNotRunning}" />
                                 <TextBlock FontSize="10"   Margin="8, 5, 5, 5"  Text="Mining (GPU)" Foreground="#FFFFFF" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,13">
-                                <CheckBox Margin="0" Style="{DynamicResource CheckBoxSlider}"  IsChecked="{Binding IsCpuActive}" />
+                                <CheckBox Margin="0" Style="{DynamicResource CheckBoxSlider}"  IsChecked="{Binding IsCpuEnabled}" />
                                 <TextBlock  FontSize="10" Margin="10, 1,0,0" TextWrapping="Wrap" Text="Golem Network (CPU)" Foreground="#FFFFFF" />
                             </StackPanel>
                         </StackPanel>
@@ -187,7 +187,7 @@
                                                     <ColumnDefinition Width="auto"/>
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
-                                                <CheckBox IsEnabled="{Binding DataContext.BenchmarkReadyToRun, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ItemsControl}}}" Grid.Column="0" IsChecked="{Binding Path=IsEnabledByUser, Delay=2000}" Margin="0,2,5,0"  Style="{DynamicResource CheckBoxGpu}" />
+                                                <CheckBox IsEnabled="{Binding DataContext.IsBenchmarkNotRunning, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ItemsControl}}}" Grid.Column="0" IsChecked="{Binding Path=IsEnabledByUser, Delay=2000}" Margin="0,2,5,0"  Style="{DynamicResource CheckBoxGpu}" />
                                                 <TextBlock Grid.Column="1" TextWrapping="Wrap" FontFamily="Segoe Ui" FontWeight="Regular" Foreground="White" FontSize="13" Text="{Binding Path=DisplayName}" Margin="0"/>
                                             </Grid>
                                             <Label Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Left" FontFamily="Segoe Ui" FontWeight="Light"  FontSize="12" Padding="0"  Content="Hashrate:" Margin="0, 5, 0, 3" />
@@ -304,7 +304,7 @@
                                             <StackPanel Grid.Column="0" Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,3,0,3">
                                                 <Label VerticalAlignment="Center" FontFamily="Segoe Ui" FontSize="12" Padding="0" FontWeight="Light" Content="Mode:" ToolTip="{Binding ClaymorePerformanceThrottlingDebug}"/>
                                             </StackPanel>
-                                            <ComboBox HorizontalAlignment="Left" Grid.Column="1" Grid.Row="3" Margin="5,0,0,0" IsEnabled="{Binding DataContext.BenchmarkReadyToRun, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ItemsControl}}}" ItemsSource="{Binding Source={StaticResource dataFromEnum}}"  FontSize="10" FontFamily="Segoe UI" Padding="0" Style="{DynamicResource MiningModeComboBox}"  SelectedItem="{Binding Path=SelectedMiningMode, Delay=2000}"  Width="90" >
+                                            <ComboBox HorizontalAlignment="Left" Grid.Column="1" Grid.Row="3" Margin="5,0,0,0" IsEnabled="{Binding DataContext.IsBenchmarkNotRunning, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ItemsControl}}}" ItemsSource="{Binding Source={StaticResource dataFromEnum}}"  FontSize="10" FontFamily="Segoe UI" Padding="0" Style="{DynamicResource MiningModeComboBox}"  SelectedItem="{Binding Path=SelectedMiningMode, Delay=2000}"  Width="90" >
 
                                             </ComboBox>
                                         </Grid>

--- a/ViewModel/DashboardMainViewModel.cs
+++ b/ViewModel/DashboardMainViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using GolemUI.Interfaces;
 
 using GolemUI.Src;
+using GolemUI.Src.AppNotificationService;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -16,7 +17,7 @@ namespace GolemUI.ViewModel
     public class DashboardMainViewModel : INotifyPropertyChanged, ISavableLoadableDashboardPage
     {
         public DashboardMainViewModel(IPriceProvider priceProvider, IPaymentService paymentService, IProviderConfig providerConfig, IProcessControler processControler, Src.BenchmarkService benchmarkService, IBenchmarkResultsProvider benchmarkResultsProvider,
-            IStatusProvider statusProvider, IHistoryDataProvider historyDataProvider, IRemoteSettingsProvider remoteSettingsProvider)
+            IStatusProvider statusProvider, IHistoryDataProvider historyDataProvider, IRemoteSettingsProvider remoteSettingsProvider, INotificationService notificationService)
         {
             _benchmarkResultsProvider = benchmarkResultsProvider;
             _priceProvider = priceProvider;
@@ -27,6 +28,7 @@ namespace GolemUI.ViewModel
             _statusProvider = statusProvider;
             _historyDataProvider = historyDataProvider;
             _remoteSettingsProvider = remoteSettingsProvider;
+            _notificationService = notificationService;
 
             _paymentService.PropertyChanged += OnPaymentServiceChanged;
             _providerConfig.PropertyChanged += OnProviderConfigChanged;
@@ -48,7 +50,7 @@ namespace GolemUI.ViewModel
             }
         }
 
-        public bool IsMiningReadyToRun => !Process.IsStarting && !_benchmarkService.IsRunning;
+        public bool IsMiningReadyToRun => !Process.IsStarting && !_benchmarkService.IsRunning && IsGpuEnabled;
         public bool IsBenchmarkNotRunning => !_benchmarkService.IsRunning;
         public string StartButtonExplanation
         {
@@ -58,6 +60,8 @@ namespace GolemUI.ViewModel
                     return "Please wait until all subsystems are initialized";
                 if (_benchmarkService.IsRunning)
                     return "Can't start mining while benchmark is running";
+                if (!_providerConfig.IsMiningActive)
+                    return "Can't start mining with GPU support disabled";
 
                 return "";
             }
@@ -227,6 +231,10 @@ namespace GolemUI.ViewModel
             OnPropertyChanged("EnabledGpuCount");
             OnPropertyChanged("GpuCardsInfo");
             OnPropertyChanged("CpuCardsInfo");
+            OnPropertyChanged(nameof(IsMiningReadyToRun));
+            OnPropertyChanged(nameof(IsGpuEnabled));
+            OnPropertyChanged(nameof(GpuStatus));
+            OnPropertyChanged(nameof(StartButtonExplanation));
         }
 
 
@@ -289,9 +297,16 @@ namespace GolemUI.ViewModel
             set
             {
                 _providerConfig.IsMiningActive = value;
+                if (value == false)
+                {
+                    _processController.Stop();
+                    _notificationService.PushNotification(new SimpleNotificationObject(Tag.AppStatus, "gpu disabled - stopping mining", expirationTimeInMs: 3000, group: false));
+                }
 
-                OnPropertyChanged("IsGpuEnabled");
-                OnPropertyChanged("GpuStatus");
+                OnPropertyChanged(nameof(IsMiningReadyToRun));
+                OnPropertyChanged(nameof(IsGpuEnabled));
+                OnPropertyChanged(nameof(GpuStatus));
+                OnPropertyChanged(nameof(StartButtonExplanation));
 
             }
         }
@@ -346,5 +361,6 @@ namespace GolemUI.ViewModel
         private readonly IBenchmarkResultsProvider _benchmarkResultsProvider;
         private readonly IHistoryDataProvider _historyDataProvider;
         private readonly IRemoteSettingsProvider _remoteSettingsProvider;
+        private readonly INotificationService _notificationService;
     }
 }

--- a/ViewModel/SettingsViewModel.cs
+++ b/ViewModel/SettingsViewModel.cs
@@ -21,7 +21,7 @@ namespace GolemUI.ViewModel
         private readonly Command.Provider _provider;
         private readonly IProviderConfig _providerConfig;
         private readonly IPriceProvider _priceProvider;
-        private readonly IProcessControler _processControler;
+        private readonly IProcessControler _processController;
         private readonly IEstimatedProfitProvider _profitEstimator;
         private readonly IStatusProvider _statusProvider;
         private readonly BenchmarkService _benchmarkService;
@@ -56,7 +56,7 @@ namespace GolemUI.ViewModel
         {
             _userSettingsProvider = userSettingsProvider;
             _statusProvider = statusProvider;
-            _processControler = processControler;
+            _processController = processControler;
             GpuList = new ObservableCollection<ClaymoreGpuStatus>();
             _notificationService = notificationService;
             _benchmarkResultsProvider = benchmarkResultsProvider;
@@ -98,7 +98,7 @@ namespace GolemUI.ViewModel
 
         public void StopMiningProcess()
         {
-            _processControler.Stop();
+            _processController.Stop();
             _notificationService.PushNotification(new SimpleNotificationObject(Tag.AppStatus, "stopping mining...", expirationTimeInMs: 3000, group: false));
         }
         public void RestartMiningProcess()
@@ -106,7 +106,7 @@ namespace GolemUI.ViewModel
 
             var extraClaymoreParams = _benchmarkService.ExtractClaymoreParams();
 
-            _processControler.Start(_providerConfig.Network, extraClaymoreParams);
+            _processController.Start(_providerConfig.Network, extraClaymoreParams);
             _notificationService.PushNotification(new SimpleNotificationObject(Tag.AppStatus, "starting mining...", expirationTimeInMs: 3000, group: false));
         }
         public bool IsMiningProcessRunning()
@@ -118,7 +118,7 @@ namespace GolemUI.ViewModel
             //    Model.ActivityState? gminerState = act.Where(a => a.ExeUnit == "gminer"/* && a.State == Model.ActivityState.StateType.Ready*/).SingleOrDefault();
             //    mining = gminerState != null;
             //}
-            mining = _processControler.IsProviderRunning;
+            mining = _processController.IsProviderRunning;
             return mining;
         }
         public void StartBenchmark()
@@ -184,7 +184,9 @@ namespace GolemUI.ViewModel
                 ActiveCpusCount = TotalCpusCount;
 
             NotifyChange("TotalCpusCountAsString");
-
+            NotifyChange(nameof(IsCpuEnabled));
+            NotifyChange(nameof(IsGpuEnabled));
+            NotifyChange(nameof(BenchmarkReadyToRun));
         }
 
         void ChangeSettingsWithMiningRestart(string msg)
@@ -194,7 +196,8 @@ namespace GolemUI.ViewModel
                 _notificationService.PushNotification(new SimpleNotificationObject(Tag.SettingsChanged, msg, expirationTimeInMs: 2000));
                 SaveData();
                 StopMiningProcess();
-                Task.Delay(3000).ContinueWith(_ => RestartMiningProcess());
+                if (IsGpuEnabled)
+                    Task.Delay(3000).ContinueWith(_ => RestartMiningProcess());
 
             }
         }
@@ -208,7 +211,19 @@ namespace GolemUI.ViewModel
                 }
                 if (e.PropertyName == "IsEnabledByUser")
                 {
+                    bool isAnyCardEnabled = false;
+                    GpuList.ToList().ForEach(x =>
+                    {
+                        isAnyCardEnabled = isAnyCardEnabled || (x.IsEnabledByUser /*&& x.IsReadyForMining*/);
+                    });
+                    if (!isAnyCardEnabled && IsGpuEnabled)
+                    {
+                        _notificationService.PushNotification(new SimpleNotificationObject(Tag.SettingsChanged, "Gpu disabled since user disabled all cards, to enable mining again please activate at least one card and enable GPU support in Task type", expirationTimeInMs: 10000, group: false));
+                        IsGpuEnabled = false;
+                    }
+
                     ChangeSettingsWithMiningRestart("applying settings (card enabled: " + status.IsEnabledByUser.ToString() + ")");
+
                 }
             }
         }
@@ -278,13 +293,14 @@ namespace GolemUI.ViewModel
                 NotifyChange("BenchmarkIsRunning");
                 NotifyChange("BenchmarkReadyToRun");
                 NotifyChange("BenchmarkError");
+                NotifyChange(nameof(IsBenchmarkNotRunning));
             }
             if (e.PropertyName == "IsRunning")
             {
                 NotifyChange("BenchmarkReadyToRun");
                 NotifyChange("BenchmarkIsRunning");
                 NotifyChange("ExpectedProfit");
-
+                NotifyChange(nameof(IsBenchmarkNotRunning));
                 if (!BenchmarkIsRunning && _benchmarkService != null)
                 {
                     // finished ?
@@ -330,27 +346,38 @@ namespace GolemUI.ViewModel
                     NotifyChange("BenchmarkIsRunning");
                     NotifyChange("BenchmarkReadyToRun");
                     NotifyChange("BenchmarkError");
+                    NotifyChange(nameof(IsBenchmarkNotRunning));
 
                 }
             }
         }
         public bool BenchmarkIsRunning => _benchmarkService.IsRunning;
-        public bool BenchmarkReadyToRun => !(_benchmarkService.IsRunning);
+        public bool BenchmarkReadyToRun => !(_benchmarkService.IsRunning) && IsGpuEnabled;
+        public bool IsBenchmarkNotRunning => !(_benchmarkService.IsRunning);
 
-        public bool IsMiningActive
+        public bool IsGpuEnabled
         {
             get => _providerConfig?.IsMiningActive ?? false;
             set
             {
                 _providerConfig.IsMiningActive = value;
+                if (value == false)
+                {
+                    _processController.Stop();
+                    _notificationService.PushNotification(new SimpleNotificationObject(Tag.AppStatus, "gpu disabled - stopping mining", expirationTimeInMs: 3000, group: false));
+                }
+                NotifyChange(nameof(IsGpuEnabled));
+                NotifyChange(nameof(IsBenchmarkNotRunning));
+                NotifyChange(nameof(BenchmarkReadyToRun));
             }
         }
-        public bool IsCpuActive
+        public bool IsCpuEnabled
         {
             get => _providerConfig?.IsCpuActive ?? false;
             set
             {
                 _providerConfig.IsCpuActive = value;
+                NotifyChange(nameof(IsCpuEnabled));
             }
         }
         public string TotalCpusCountAsString => TotalCpusCount.ToString();


### PR DESCRIPTION
- when gpu is disabled:
- - mining is stopped
- - benchmark can't be run
- gpu sldiers now correctly retrieve and sets their state between different pages (dashboard main & settings)
- also removed ativating gminer and wasm presets by default when app starts