### PR TITLE
default value for opacity slider is set to =80

### DIFF
--- a/Model/UserSettings.cs
+++ b/Model/UserSettings.cs
@@ -109,7 +109,7 @@ namespace GolemUI.Model
             }
         }
 
-        public int? _opacity = null;
+        public int? _opacity = 80;
         public int? Opacity
         {
             get


### PR DESCRIPTION
fixes https://github.com/golemfactory/ya-provider-winui/issues/129
![image](https://user-images.githubusercontent.com/22456155/129871283-3e92a213-964d-4dd5-b6b3-ec76953a998d.png)
