### PR TITLE
App now closes and opens from tray after fresh install

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -137,7 +137,7 @@ namespace GolemUI
 
             if (_dashboard == null)
             {
-                throw new Exception("FATAL EXCEPTION, Dashboard object creation failed.");
+                throw new Exception("FATAL ERROR, Dashboard object creation failed.");
             }
             return _dashboard;
         }

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -31,7 +31,7 @@ namespace GolemUI
         private readonly GolemUI.ChildProcessManager _childProcessManager;
         private readonly IDisposable _sentrySdk;
 
-        private Dashboard? _dashboard;
+        private Dashboard? _dashboard = null;
         public App()
         {
             this.DispatcherUnhandledException += App_DispatcherUnhandledException;
@@ -128,6 +128,18 @@ namespace GolemUI
                 logBuilder.AddSentry(GolemUI.Properties.Settings.Default.SentryDsn);
             });
 
+        }
+
+        public Dashboard? GetOrCreateDashboardWindow()
+        {
+            if (_dashboard == null)
+                _dashboard = _serviceProvider!.GetRequiredService<Dashboard>();
+
+            if (_dashboard == null)
+            {
+                throw new Exception("FATAL EXCEPTION, Dashboard object creation failed.");
+            }
+            return _dashboard;
         }
 
         private void OnStartup(object sender, StartupEventArgs e)

--- a/UI/SetupWindow.xaml.cs
+++ b/UI/SetupWindow.xaml.cs
@@ -191,8 +191,8 @@ namespace GolemUI.UI
         private void OnNoobFinish(object sender, RoutedEventArgs e)
         {
             Model!.Save();
-            var wnd = _serviceProvider.GetService(typeof(GolemUI.Dashboard)) as GolemUI.Dashboard;
-            wnd?.Show();
+            if (App.Current is App app)
+                app.GetOrCreateDashboardWindow().Show();
             Close();
         }
 
@@ -257,8 +257,8 @@ namespace GolemUI.UI
         private void BtnNoGpuContinue_Click(object sender, RoutedEventArgs e)
         {
             Model!.Save();
-            var wnd = _serviceProvider.GetService(typeof(GolemUI.Dashboard)) as GolemUI.Dashboard;
-            wnd?.Show();
+            if (App.Current is App app)
+                app.GetOrCreateDashboardWindow().Show();
             Close();
         }
     }


### PR DESCRIPTION
fixes: https://github.com/golemfactory/ya-provider-winui/issues/128

App::OnStartup

_dashboard = dashboardWindow was not invoked when app was starting for the first time (early return from method) and therefore it was null in subsequent calls which prevented actions invoked by tray menu


now _dashboard is set to proper instance in GetOrCreateDashboardWindow method when SetupWindow closes and opens Dashboard window
