### PR TITLE
Feature/broadcastmonkey/wallet withdraw after changed address

### DIFF
--- a/DesignViewModel/WalletView.cs
+++ b/DesignViewModel/WalletView.cs
@@ -30,7 +30,10 @@ namespace GolemUI.DesignViewModel
 
         public bool IsCpuActive { get; set; } = false;
 
+        public bool ShouldDisplayAdditionalInternalWallet => true;
 
+        public decimal InternalBalance => 123.23m;
+        public string InternalAddress => "0xa1a7c282badfa6bd188a6d42b5bc7fa1e836dddd";
 
         public WalletView()
         {

--- a/GolemUI.csproj
+++ b/GolemUI.csproj
@@ -636,6 +636,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="UI\Themes\Buttons\BlueButton.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="UI\Themes\Buttons\HistoryTabButton.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -684,7 +688,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
-    <Page Include="UI\Themes\Buttons\BlueButton.xaml">
+    <Page Include="UI\Themes\Buttons\RoundedBlueButton.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
@@ -946,6 +950,10 @@
     <Resource Include="UI\Icons\DefaultStyle\png\Sequences\Gpu\GPU_icon0037.png" />
     <Resource Include="UI\Icons\DefaultStyle\png\Sequences\Gpu\GPU_icon0038.png" />
     <Resource Include="UI\Icons\DefaultStyle\png\Sequences\Gpu\GPU_icon0039.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Resource Include="UI\Icons\DefaultStyle\png\Wallet\copy-icon.png" />
+    <Resource Include="UI\Icons\DefaultStyle\png\Wallet\edit-icon.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Interfaces/IPaymentService.cs
+++ b/Interfaces/IPaymentService.cs
@@ -11,6 +11,7 @@ namespace GolemUI.Interfaces
     public interface IPaymentService : INotifyPropertyChanged
     {
         WalletState? State { get; }
+        WalletState? InternalWalletState { get; }
 
         string? LastError { get; }
 

--- a/Src/PaymentService.cs
+++ b/Src/PaymentService.cs
@@ -145,7 +145,7 @@ namespace GolemUI.Src
 
                 if (walletAddress != _buildInAdress)
                 {
-                    if (_shouldCheckForInternalWallet && _buildInAdress !=null)
+                    if (_shouldCheckForInternalWallet && _buildInAdress != null)
                     {
                         var internalWalletstate = await GetWalletState(_buildInAdress);
                         if (internalWalletstate == null || internalWalletstate?.Balance == 0) _shouldCheckForInternalWallet = false;

--- a/Src/PaymentService.cs
+++ b/Src/PaymentService.cs
@@ -28,6 +28,7 @@ namespace GolemUI.Src
         private ILogger<PaymentService> _logger;
 
         public event PropertyChangedEventHandler? PropertyChanged;
+        private bool _shouldCheckForInternalWallet = true;
 
         public PaymentService(Network network, Command.YagnaSrv srv, IProcessController processController, IProviderConfig providerConfig, Command.GSB.Payment gsbPayment, ILogger<PaymentService> logger)
         {
@@ -57,6 +58,22 @@ namespace GolemUI.Src
 
         public WalletState? State { get; private set; }
 
+        private WalletState? _internalWalletState;
+        public WalletState? InternalWalletState
+        {
+            get
+            {
+                if (Address == InternalAddress)
+                    return State;
+
+                return _internalWalletState;
+            }
+            private set
+            {
+                _internalWalletState = value;
+            }
+        }
+
         public string? LastError { get; private set; }
 
         public string? Address => _walletAddress ?? _buildInAdress;
@@ -76,6 +93,27 @@ namespace GolemUI.Src
             _walletAddress = _providerConfig.Config?.Account ?? _buildInAdress;
             UpdateState();
             OnPropertyChanged("Address");
+        }
+
+        private async Task<WalletState> GetWalletState(String walletAddress)
+        {
+            var since = DateTime.UtcNow - TimeSpan.FromDays(2);
+            var output = await Task.WhenAll(
+                   _gsbPayment.GetStatus(walletAddress, "polygon", since: since, network: _network.Id)
+               );
+            //var statusOnL1 = output[1];
+            //var amountOnL1 = statusOnL1?.Amount ?? 0;
+
+            var statusOnL2 = output[0];
+            var pending = (statusOnL2?.Incoming?.Accepted?.TotalAmount ?? 0m) - (statusOnL2?.Incoming?.Confirmed?.TotalAmount ?? 0m);
+            var amountOnL2 = statusOnL2?.Amount ?? 0;
+            var state = new WalletState(statusOnL2?.Token ?? "GLM")
+            {
+                Balance = /*amountOnL1 + */amountOnL2,
+                PendingBalance = pending,
+                BalanceOnL2 = amountOnL2
+            };
+            return state;
         }
 
         public async Task Refresh()
@@ -102,26 +140,23 @@ namespace GolemUI.Src
                     throw new Exception("Wallet address is null");
                 }
 
-                var since = DateTime.UtcNow - TimeSpan.FromDays(2);
+                var state = await GetWalletState(walletAddress);
 
-                var output = await Task.WhenAll(
-                    _gsbPayment.GetStatus(walletAddress, "polygon", since: since, network: _network.Id)
-                );
 
-                var statusOnL2 = output[0];
-                //var statusOnL1 = output[1];
-
-                var pending = (statusOnL2?.Incoming?.Accepted?.TotalAmount ?? 0m) - (statusOnL2?.Incoming?.Confirmed?.TotalAmount ?? 0m);
-                var amountOnL2 = statusOnL2?.Amount ?? 0;
-                //var amountOnL1 = statusOnL1?.Amount ?? 0;
-
-                var state = new WalletState(statusOnL2?.Token ?? "GLM")
+                if (walletAddress != _buildInAdress)
                 {
-                    Balance = /*amountOnL1 + */amountOnL2,
-                    PendingBalance = pending,
-                    BalanceOnL2 = amountOnL2
-                };
+                    if (_shouldCheckForInternalWallet)
+                    {
+                        var internalWalletstate = await GetWalletState(_buildInAdress);
+                        if (internalWalletstate.Balance == 0) _shouldCheckForInternalWallet = false;
 
+                        if (internalWalletstate != InternalWalletState)
+                        {
+                            InternalWalletState = internalWalletstate;
+                            OnPropertyChanged("InternalWalletState");
+                        }
+                    }
+                }
                 var oldState = State;
                 LastError = null;
                 if (state != oldState)

--- a/Src/PaymentService.cs
+++ b/Src/PaymentService.cs
@@ -145,10 +145,10 @@ namespace GolemUI.Src
 
                 if (walletAddress != _buildInAdress)
                 {
-                    if (_shouldCheckForInternalWallet)
+                    if (_shouldCheckForInternalWallet && _buildInAdress !=null)
                     {
                         var internalWalletstate = await GetWalletState(_buildInAdress);
-                        if (internalWalletstate.Balance == 0) _shouldCheckForInternalWallet = false;
+                        if (internalWalletstate == null || internalWalletstate?.Balance == 0) _shouldCheckForInternalWallet = false;
 
                         if (internalWalletstate != InternalWalletState)
                         {

--- a/UI/DashboardWallet.xaml
+++ b/UI/DashboardWallet.xaml
@@ -17,6 +17,7 @@
                 <ResourceDictionary Source="/UI/Themes/Buttons/GolemLogo.xaml"/>
                 <ResourceDictionary Source="/UI/Themes/Buttons/PinkButton.xaml"/>
                 <ResourceDictionary Source="/UI/Themes/Buttons/HyperLinkButton.xaml"/>
+                <ResourceDictionary Source="/UI/Themes/Buttons/RoundedBlueButton.xaml"/>
                 <ResourceDictionary Source="/UI/Themes/Buttons/GradientButton.xaml"/>
                 <ResourceDictionary Source="/UI/Icons/Profit_icon.xaml"/>
                 <ResourceDictionary Source="/UI/Icons/DefaultStyle/xaml/Wallet/WalletIcon.xaml"/>
@@ -57,14 +58,33 @@
                 </Grid.RowDefinitions>
 
 
+                <WrapPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3">
+                    <WrapPanel Margin="8,19,8,6"  VerticalAlignment="Center"  Height="20">
+                        <TextBlock VerticalAlignment="Center"><Run Text="Your Address: "/><Run Text="{Binding WalletAddress, Mode=OneWay}" /></TextBlock>
 
-                <WrapPanel Margin="8,19,8,19" Grid.Column="0" Grid.ColumnSpan="3" VerticalAlignment="Center" Grid.Row="0" Height="16">
-                    <TextBlock><Run Text="Your Address: "/><Run Text="{Binding WalletAddress, Mode=OneWay}" /></TextBlock>
+                        <Button x:Name="BtnCopyWalletAddress" Style="{StaticResource RoundedBlueButtonStyle}" Margin="11, 0, 5, 0" Click="Copy_Click" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="20">
+                            <StackPanel Orientation="Horizontal" Margin="8,0,8,0" VerticalAlignment="Center">
+                                <Image Source="/UI/Icons/DefaultStyle/png/Wallet/copy-icon.png"  VerticalAlignment="Bottom" Margin="0,0,4,2" Width="12"/>
+                                <Label FontSize="10" Content="COPY" Margin="0" Padding="0" />
+                            </StackPanel>
+                        </Button>
+                        <Button x:Name="BtnEditWalletAddress" Style="{StaticResource RoundedBlueButtonStyle}" Margin="11, 0, 5, 0" Click="BtnEditWalletAddress_Click" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="20" VerticalContentAlignment="Center">
+                            <StackPanel Orientation="Horizontal" Margin="8,0,8,0" VerticalAlignment="Center">
+                                <Image Source="/UI/Icons/DefaultStyle/png/Wallet/edit-icon.png"  VerticalAlignment="Bottom" Margin="0,1,4,0" Width="12"/>
+                                <Label FontSize="10" Content="EDIT" Margin="0" Padding="0" />
+                            </StackPanel>
+                        </Button>
+                    </WrapPanel>
 
-                    <Button Style="{DynamicResource HyperLinkButtonStyle}" Margin="11, 0, 5, 0" Click="Copy_Click" Content="Copy ⎘"/>
-                    <Button x:Name="BtnEditWalletAddress" Style="{DynamicResource HyperLinkButtonStyle}" Margin="11, 0, 5, 0" Click="BtnEditWalletAddress_Click" Content="Edit ✍"/>
+                    <WrapPanel Margin="8,0" VerticalAlignment="Center"  Height="20" Visibility="{Binding ShouldDisplayAdditionalInternalWallet, Converter={StaticResource BoolToVisibleConverter}}">
+                        <TextBlock FontSize="9" VerticalAlignment="Center"><Run Text="Internal address: "/><Run FontWeight="Bold" Text="{Binding InternalBalance, Mode=OneWay, ConverterParameter=GLM, Converter={StaticResource AmountConverter}}"/><Run Text="  " /><Run Text="{Binding InternalAddress, Mode=OneWay}" /></TextBlock>
+                        <Button x:Name="BtnWithdrawInternal" Style="{StaticResource RoundedBlueButtonStyle}" Margin="11, 0, 5, 0" Click="BtnWithdraw_Click" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="20" >
+                            <StackPanel Orientation="Horizontal" Margin="8,0,8,0" VerticalAlignment="Center">
+                                <Label FontSize="10" Content="WITHDRAW FROM INTERNAL WALLET" Margin="0,0,0,1" Padding="0" />
+                            </StackPanel>
+                        </Button>
+                    </WrapPanel>
                 </WrapPanel>
-
                 <StackPanel Grid.Row="0" Grid.Column="4" Grid.ColumnSpan="1" VerticalAlignment="Center">
                     <Button x:Name="BtnWithdraw" Style="{StaticResource GradientButtonStyle}" Padding="10" Visibility="{Binding IsInternal, Converter={StaticResource BoolToVisibleConverter}}" Click="BtnWithdraw_Click" Content="Withdraw"/>
                     <Button x:Name="BtnOpenL2" Style="{StaticResource GradientButtonStyle}" Padding="10" Visibility="{Binding IsInternal, Converter={StaticResource BoolToHiddenConverter}}" Click="BtnOpenL2_Click" Content="Withdraw tutorial"/>

--- a/UI/DashboardWallet.xaml
+++ b/UI/DashboardWallet.xaml
@@ -63,8 +63,8 @@
                         <TextBlock VerticalAlignment="Center"><Run Text="Your Address: "/><Run Text="{Binding WalletAddress, Mode=OneWay}" /></TextBlock>
 
                         <Button x:Name="BtnCopyWalletAddress" Style="{StaticResource RoundedBlueButtonStyle}" Margin="11, 0, 5, 0" Click="Copy_Click" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="20">
-                            <StackPanel Orientation="Horizontal" Margin="8,0,8,0" VerticalAlignment="Center">
-                                <Image Source="/UI/Icons/DefaultStyle/png/Wallet/copy-icon.png"  VerticalAlignment="Bottom" Margin="0,0,4,2" Width="12"/>
+                            <StackPanel Orientation="Horizontal" Margin="8,1,8,0" VerticalAlignment="Center">
+                                <Image Source="/UI/Icons/DefaultStyle/png/Wallet/copy-icon.png"  VerticalAlignment="Bottom" Margin="0,1,4,2" Width="12"/>
                                 <Label FontSize="10" Content="COPY" Margin="0" Padding="0" />
                             </StackPanel>
                         </Button>

--- a/UI/DashboardWallet.xaml
+++ b/UI/DashboardWallet.xaml
@@ -59,16 +59,16 @@
 
 
                 <WrapPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3">
-                    <WrapPanel Margin="8,19,8,6"  VerticalAlignment="Center"  Height="20">
+                    <WrapPanel Margin="8,19,8,6"  VerticalAlignment="Center"  Height="22">
                         <TextBlock VerticalAlignment="Center"><Run Text="Your Address: "/><Run Text="{Binding WalletAddress, Mode=OneWay}" /></TextBlock>
 
-                        <Button x:Name="BtnCopyWalletAddress" Style="{StaticResource RoundedBlueButtonStyle}" Margin="11, 0, 5, 0" Click="Copy_Click" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="20">
+                        <Button x:Name="BtnCopyWalletAddress" Style="{StaticResource RoundedBlueButtonStyle}" Margin="11, 0, 5, 0" Click="Copy_Click" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="22">
                             <StackPanel Orientation="Horizontal" Margin="8,1,8,0" VerticalAlignment="Center">
                                 <Image Source="/UI/Icons/DefaultStyle/png/Wallet/copy-icon.png"  VerticalAlignment="Bottom" Margin="0,1,4,2" Width="12"/>
                                 <Label FontSize="10" Content="COPY" Margin="0" Padding="0" />
                             </StackPanel>
                         </Button>
-                        <Button x:Name="BtnEditWalletAddress" Style="{StaticResource RoundedBlueButtonStyle}" Margin="11, 0, 5, 0" Click="BtnEditWalletAddress_Click" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="20" VerticalContentAlignment="Center">
+                        <Button x:Name="BtnEditWalletAddress" Style="{StaticResource RoundedBlueButtonStyle}" Margin="11, 0, 5, 0" Click="BtnEditWalletAddress_Click" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="22" VerticalContentAlignment="Center">
                             <StackPanel Orientation="Horizontal" Margin="8,0,8,0" VerticalAlignment="Center">
                                 <Image Source="/UI/Icons/DefaultStyle/png/Wallet/edit-icon.png"  VerticalAlignment="Bottom" Margin="0,1,4,0" Width="12"/>
                                 <Label FontSize="10" Content="EDIT" Margin="0" Padding="0" />
@@ -76,9 +76,9 @@
                         </Button>
                     </WrapPanel>
 
-                    <WrapPanel Margin="8,0" VerticalAlignment="Center"  Height="20" Visibility="{Binding ShouldDisplayAdditionalInternalWallet, Converter={StaticResource BoolToVisibleConverter}}">
+                    <WrapPanel Margin="8,0" VerticalAlignment="Center"  Height="22" Visibility="{Binding ShouldDisplayAdditionalInternalWallet, Converter={StaticResource BoolToVisibleConverter}}">
                         <TextBlock FontSize="9" VerticalAlignment="Center"><Run Text="Internal address: "/><Run FontWeight="Bold" Text="{Binding InternalBalance, Mode=OneWay, ConverterParameter=GLM, Converter={StaticResource AmountConverter}}"/><Run Text="  " /><Run Text="{Binding InternalAddress, Mode=OneWay}" /></TextBlock>
-                        <Button x:Name="BtnWithdrawInternal" Style="{StaticResource RoundedBlueButtonStyle}" Margin="11, 0, 5, 0" Click="BtnWithdraw_Click" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="20" >
+                        <Button x:Name="BtnWithdrawInternal" Style="{StaticResource RoundedBlueButtonStyle}" Margin="11, 0, 5, 0" Click="BtnWithdraw_Click" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="22" >
                             <StackPanel Orientation="Horizontal" Margin="8,0,8,0" VerticalAlignment="Center">
                                 <Label FontSize="10" Content="WITHDRAW FROM INTERNAL WALLET" Margin="0,0,0,1" Padding="0" />
                             </StackPanel>

--- a/UI/DashboardWallet.xaml.cs
+++ b/UI/DashboardWallet.xaml.cs
@@ -78,5 +78,7 @@ namespace GolemUI
         {
             System.Diagnostics.Process.Start("explorer.exe", "https://www.thorg.io/usage#Layer-2");
         }
+
+
     }
 }

--- a/UI/Icons/DefaultStyle/png/Wallet/copy-icon.png
+++ b/UI/Icons/DefaultStyle/png/Wallet/copy-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7857e7c97945c1cd2b392c5f06d5e92e0cb8f2b89a0e0943b223fd4789a41402
+size 508

--- a/UI/Icons/DefaultStyle/png/Wallet/edit-icon.png
+++ b/UI/Icons/DefaultStyle/png/Wallet/edit-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39b6ce25f79a269f91e43982759f8abf88d0ba3caa92c90e2d8c15f97d5fc69d
+size 558

--- a/UI/Themes/Buttons/RoundedBlueButton.xaml
+++ b/UI/Themes/Buttons/RoundedBlueButton.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                      xmlns:local="clr-namespace:GolemUI">
+    <!-- todo: refactor it in a single buttonWithimage lib -->
     <Style x:Key="FocusVisual">
         <Setter Property="Control.Template">
             <Setter.Value>
@@ -13,16 +14,19 @@
     <SolidColorBrush x:Key="Button.Static.Background" Color="#261D5E"/>
     <SolidColorBrush x:Key="Button.Static.Border" Color="#74708C"/>
     <SolidColorBrush x:Key="Button.Static.Foreground" Color="#FFFFFF"/>
-    <SolidColorBrush x:Key="Button.MouseOver.Background" Color="blue"/>
+    <SolidColorBrush x:Key="Button.MouseOver.Background" Color="#413878"/>
     <SolidColorBrush x:Key="Button.MouseOver.Border" Color="#74708C"/>
     <SolidColorBrush x:Key="Button.MouseOver.Foreground" Color="#FFFFFF"/>
-    <SolidColorBrush x:Key="Button.Pressed.Background" Color="white"/>
+    <SolidColorBrush x:Key="Button.Pressed.Background" Color="#1B1F74"/>
     <SolidColorBrush x:Key="Button.Pressed.Border" Color="#74708C"/>
     <SolidColorBrush x:Key="Button.Pressed.Foreground" Color="black"/>
     <SolidColorBrush x:Key="Button.Disabled.Background" Color="#261D5E"/>
     <SolidColorBrush x:Key="Button.Disabled.Border" Color="#74708C"/>
     <SolidColorBrush x:Key="Button.Disabled.Foreground" Color="#AAAAAA"/>
-    <Style x:Key="BlueButtonStyle" TargetType="{x:Type Button}">
+
+    <Style x:Key="RoundedBlueButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Focusable" Value="False" />
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
         <Setter Property="Background" Value="{StaticResource Button.Static.Background}"/>
         <Setter Property="BorderBrush" Value="{StaticResource Button.Static.Border}"/>
@@ -33,13 +37,16 @@
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Padding" Value="1"/>
-        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="FontWeight" Value="Regular"/>
+
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="{x:Type Button}">
-                    <Border x:Name="border" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="true">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="true" CornerRadius="1">
                         <ContentPresenter x:Name="contentPresenter" Focusable="False" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                        
                     </Border>
+
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsDefaulted" Value="true">
                             <Setter Property="Background" TargetName="border" Value="{StaticResource Button.Static.Background}"/>
@@ -47,6 +54,7 @@
                             <Setter Property="TextElement.Foreground" TargetName="contentPresenter" Value="{StaticResource Button.Static.Foreground}"/>
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
+                            <Setter Property="Cursor" Value="Hand"/>
                             <Setter Property="Background" TargetName="border" Value="{StaticResource Button.MouseOver.Background}"/>
                             <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource Button.MouseOver.Border}"/>
                             <Setter Property="TextElement.Foreground" TargetName="contentPresenter" Value="{StaticResource Button.MouseOver.Foreground}"/>
@@ -66,5 +74,4 @@
             </Setter.Value>
         </Setter>
     </Style>
-
 </ResourceDictionary>

--- a/ViewModel/Dialogs/DlgWithdrawViewModel.cs
+++ b/ViewModel/Dialogs/DlgWithdrawViewModel.cs
@@ -31,7 +31,7 @@ namespace GolemUI.ViewModel.Dialogs
     public class DlgWithdrawViewModel : INotifyPropertyChanged
     {
 
-        Model.WalletState _walletState;
+        Model.WalletState? _walletState;
         public DlgWithdrawViewModel(Interfaces.IPaymentService paymentService, Interfaces.IPriceProvider priceProvider, bool isInternal)
         {
             _withdrawAddress = "";

--- a/ViewModel/Dialogs/DlgWithdrawViewModel.cs
+++ b/ViewModel/Dialogs/DlgWithdrawViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using GolemUI.Command.GSB;
 using GolemUI.Interfaces;
+using GolemUI.Model;
 using Nethereum.Util;
 using System;
 using System.Collections.Generic;
@@ -30,10 +31,13 @@ namespace GolemUI.ViewModel.Dialogs
     public class DlgWithdrawViewModel : INotifyPropertyChanged
     {
 
-        public DlgWithdrawViewModel(Interfaces.IPaymentService paymentService, Interfaces.IPriceProvider priceProvider)
+        Model.WalletState _walletState;
+        public DlgWithdrawViewModel(Interfaces.IPaymentService paymentService, Interfaces.IPriceProvider priceProvider, bool isInternal)
         {
             _withdrawAddress = "";
-            _amount = paymentService.State?.BalanceOnL2;
+            _walletState = !isInternal ? paymentService.InternalWalletState : paymentService.State;
+
+            _amount = _walletState?.BalanceOnL2;
 
             _paymentService = paymentService;
             _priceProvider = priceProvider;
@@ -69,7 +73,7 @@ namespace GolemUI.ViewModel.Dialogs
 
         public decimal AmountUSD => _priceProvider.CoinValue(Amount ?? 0m, Model.Coin.GLM);
 
-        public decimal? AvailableGLM => _paymentService.State?.BalanceOnL2;
+        public decimal? AvailableGLM => _walletState?.BalanceOnL2;
         public decimal AvailableUSD => _priceProvider.CoinValue(AvailableGLM ?? 0m, Model.Coin.GLM);
 
 

--- a/ViewModel/WalletViewModel.cs
+++ b/ViewModel/WalletViewModel.cs
@@ -47,6 +47,7 @@ namespace GolemUI.ViewModel
 
             this._walletAddress = wallet;
             this._amount = 0;
+            this._internalBalance = 0;
             this._pendingAmount = 0;
             this.Tickler = "GLM";
             var state = _paymentService.State;
@@ -136,6 +137,20 @@ namespace GolemUI.ViewModel
 
         private void OnPaymentStateChanged(object? sender, PropertyChangedEventArgs e)
         {
+
+            if (e.PropertyName == "InternalWalletState")
+            {
+                var internalState = _paymentService.InternalWalletState;
+                if (internalState != null)
+                {
+                    this._internalBalance = internalState.Balance ?? 0m;
+
+                    OnPropertyChanged(nameof(InternalBalance));
+                    OnPropertyChanged(nameof(ShouldDisplayAdditionalInternalWallet));
+                }
+
+            }
+
             var state = _paymentService.State;
 
             if (state != null)
@@ -153,6 +168,7 @@ namespace GolemUI.ViewModel
             {
                 OnPropertyChanged("WalletAddress");
                 OnPropertyChanged("IsInternal");
+                OnPropertyChanged("InternalAddress");
             }
         }
 
@@ -198,6 +214,13 @@ namespace GolemUI.ViewModel
 
         public bool IsInternal => _paymentService.Address == _paymentService.InternalAddress;
 
+        public string InternalAddress => _paymentService.InternalAddress;
+
+        public bool ShouldDisplayAdditionalInternalWallet => !IsInternal && InternalBalance > 0;
+        private decimal _internalBalance = 0;
+
+        public decimal InternalBalance => _internalBalance;
+
         public event PropertyChangedEventHandler? PropertyChanged;
         public void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         {
@@ -208,7 +231,7 @@ namespace GolemUI.ViewModel
         }
 
         public DlgEditAddressViewModel EditModel => new DlgEditAddressViewModel(_paymentService);
-        public DlgWithdrawViewModel WithDrawModel => new DlgWithdrawViewModel(_paymentService, _priceProvider);
+        public DlgWithdrawViewModel WithDrawModel => new DlgWithdrawViewModel(_paymentService, _priceProvider, IsInternal);
 
         public void Dispose()
         {


### PR DESCRIPTION
Changes:

- Payment service now also checks for balance of internal address if it was changed for external wallet
- If balance of beforementioned address is > 0 then app allows to withdraw funds from that wallet 




![image](https://user-images.githubusercontent.com/22456155/141484290-ffb7547c-13ea-477b-9f16-f8650be01b10.png)

![image](https://user-images.githubusercontent.com/22456155/141484581-825621f6-eba5-40da-9a70-6233953e7898.png)

![image](https://user-images.githubusercontent.com/22456155/141484614-20e2db50-0603-4a1b-8883-e4b7c588b787.png)

![image](https://user-images.githubusercontent.com/22456155/141484636-f9225c3d-853a-4f4d-b6d0-ee9a51f6cb45.png)


![image](https://user-images.githubusercontent.com/22456155/141484683-5e3552f7-146a-4917-8b67-b08117bab7f9.png)
