### PR TITLE
Hotfix/broadcastmonkey/dashboard main toolip payment error

### DIFF
--- a/DesignViewModel/DashboardMainViewModel.cs
+++ b/DesignViewModel/DashboardMainViewModel.cs
@@ -14,7 +14,9 @@ namespace GolemUI.DesignViewModel
                            "(Settings). You can rerun benchmark to determine gpu capabilities again.";
         public string GpuStatus => "Ready";
         public string? GpuStatusAnnotation => "20.15 MH/s";
-        public string? PaymentStateError => "No connection to payment service";
+        public string? PaymentStateMessage => "Unable to get account's balance";
+        public string PolygonLink => "https://polygonscan.com/token/0x0b220b82f3ea3b7f6d9a1d8ab58930c064a2b5bf?a=0x00000000000000000000000000000123";
+        public bool ShouldPaymentMessageTooltipBeAccessible => true;
         public string CpuStatus => "Ready";
         public decimal AmountUSD => 0.00m;
         public decimal Amount => 0;

--- a/Interfaces/IPaymentService.cs
+++ b/Interfaces/IPaymentService.cs
@@ -14,6 +14,7 @@ namespace GolemUI.Interfaces
 
         string? LastError { get; }
 
+        DateTime? LastSuccessfullRefresh { get; }
         string? Address { get; }
 
         string InternalAddress { get; }

--- a/Miners/TRex/TRexParser.cs
+++ b/Miners/TRex/TRexParser.cs
@@ -75,7 +75,7 @@ namespace GolemUI.Miners.TRex
         {
             lock (__lockObj)
             {
-                return (BenchmarkLiveStatus) _liveStatus.Clone();
+                return (BenchmarkLiveStatus)_liveStatus.Clone();
                 // Your code...
             }
         }
@@ -151,7 +151,7 @@ namespace GolemUI.Miners.TRex
                 var result = await client.GetStringAsync(httpAddress);
                 TRexDetails? details = JsonConvert.DeserializeObject<TRexDetails>(result);
 
-                
+
                 return true;
             }
         }

--- a/Src/PaymentService.cs
+++ b/Src/PaymentService.cs
@@ -27,6 +27,8 @@ namespace GolemUI.Src
         private DispatcherTimer _timer;
         private ILogger<PaymentService> _logger;
 
+        public DateTime? LastSuccessfullRefresh { get; private set; } = null;
+
         public event PropertyChangedEventHandler? PropertyChanged;
 
         public PaymentService(Network network, Command.YagnaSrv srv, IProcessController processController, IProviderConfig providerConfig, Command.GSB.Payment gsbPayment, ILogger<PaymentService> logger)
@@ -129,6 +131,7 @@ namespace GolemUI.Src
                     State = state;
                     OnPropertyChanged("State");
                 }
+                LastSuccessfullRefresh = DateTime.Now;
             }
             catch (HttpRequestException ex)
             {

--- a/UI/DashboardMain.xaml
+++ b/UI/DashboardMain.xaml
@@ -72,10 +72,10 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <local:DashboardStatusControl Status="{Binding Path=Status}"  StatusAdditionalInfo="{Binding Path=StatusAdditionalInfo}"  Margin="0,0,0,4" Grid.ColumnSpan="2" />
-                
+
                 <Button Click="btnStop_Click" Margin="0,15,0,0" Style="{StaticResource GradientButtonStyle}" VerticalAlignment="Bottom" Height="45" Grid.Column="4" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" IsEnabled="{Binding Path=Process.IsStarting, Converter={StaticResource InverseBooleanConverter}}" Visibility="{Binding Path=Process.IsProviderRunning, Converter={StaticResource BoolToVisibleConverter}}">Stop Mining</Button>
 
-              
+
 
                 <Button Style="{StaticResource GradientButtonStyle}" Click="btnStart_Click"  Margin="0,15,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" Height="45" Grid.Row="0" Grid.Column="4" Grid.ColumnSpan="3" IsEnabled="{Binding Path=IsMiningReadyToRun, Mode=OneWay}" Visibility="{Binding Path=Process.IsProviderRunning, Converter={StaticResource BoolToHiddenConverter}}">Start Mining</Button>
                 <TextBlock  Grid.ColumnSpan="3" TextWrapping="WrapWithOverflow"  Text="{Binding StartButtonExplanation}" Grid.Column="4" Grid.Row="1" Margin="0,5,0,0" FontSize="12"></TextBlock>
@@ -92,7 +92,32 @@
                         </Grid.RowDefinitions>
                         <Label Content="My Balance" FontSize="14" Margin="17,22,0,0" Grid.ColumnSpan="2"/>
                         <Image Source="Icons/DefaultStyle/png/Dashboard/Balance.png" Grid.Column="0" Grid.Row="1" Margin="23, 23" Stretch="Uniform" VerticalAlignment="Top"  RenderOptions.BitmapScalingMode="HighQuality" />
-                        <TextBox Text="{Binding Path=PaymentStateError, Mode=OneWay}" Grid.Column="1" Style="{DynamicResource PaymentStatusErrorMsg}" Margin="3, 5, 5, 5" VerticalAlignment="bottom"></TextBox>
+                        <Label x:Name="lblPaymentStateMessage" Content="{Binding Path=PaymentStateMessage, Mode=OneWay}" MouseEnter="lblPaymentStateMessage_MouseEnter" 
+                             Grid.Column="1" Foreground="#99b" Margin="0, 5, 5, 1" VerticalAlignment="bottom"  HorizontalAlignment="Left"/>
+                        <Popup x:Name="tooltip" PlacementTarget="{Binding ElementName=lblPaymentStateMessage}" MouseLeave="lblPaymentStateMessage_MouseLeave" Placement="Bottom">
+                            <Border x:Name="border" BorderBrush="#74708C" BorderThickness="1" Background="#120539" SnapsToDevicePixels="true" CornerRadius="1">
+
+                                <StackPanel Margin="4">
+                                    <Label FontSize="10" Content="It seems that Thorg is unable to get your current account's balance." Padding="0"/>
+                                    <Label FontSize="10" Content="" Padding="0"/>
+                                    <Label FontSize="10" Content="Please check if your Internet connection is working properly, if error persists try restarting Thorg." Padding="0"/>
+                                    <Label FontSize="10" Content="" Padding="0"/>
+                                    <Label FontSize="10" Content="There might be a problem with connection to polygon gateway that returns your account's balance. " Padding="0"/>
+                                    <Label FontSize="10" Content="" Padding="0"/>
+                                    <Label FontSize="10" Content="Good news is that you can still mine with Thorg! " Padding="0"/>
+                                    <Label FontSize="10" Content="" Padding="0"/>
+                                    <Label FontSize="10" Content="Your balance should appear here later, once polygon gateway is reachable again. " Padding="0"/>
+                                    <Label FontSize="10" Content="" Padding="0"/>
+                                    <Label FontSize="10" Content="If you would like to check your balance now, you can do it with polygonscan by following this link: " Padding="0"/>
+                                    <TextBlock TextDecorations="Underline" >
+                    <Hyperlink Foreground="white" NavigateUri="{Binding PolygonLink}" Click="Hyperlink_Click">
+                        <TextBlock FontSize="10" Text="{Binding PolygonLink}" />
+                        </Hyperlink>
+                                        </TextBlock>
+                                </StackPanel>
+                            </Border>
+                        </Popup>
+
                         <StackPanel Orientation="Vertical" Grid.Row="1" Grid.Column="1" Margin="0,13,0,0">
                             <Label Content="{Binding Path=AmountUSD, Converter={StaticResource AmountConverter}}" Foreground="#FFFFFF" FontFamily="Segoe UI Black" FontSize="42" Margin="0, -12"></Label>
                             <Label Content="{Binding Path=Amount, Converter={StaticResource AmountConverter}, ConverterParameter=GLM}" Foreground="#99b"  FontSize="14" Margin="0, 10"></Label>

--- a/UI/DashboardMain.xaml
+++ b/UI/DashboardMain.xaml
@@ -98,17 +98,17 @@
                             <Border x:Name="border" BorderBrush="#74708C" BorderThickness="1" Background="#120539" SnapsToDevicePixels="true" CornerRadius="1">
 
                                 <StackPanel Margin="4">
-                                    <Label FontSize="10" Content="It seems that Thorg is unable to get your current account's balance." Padding="0"/>
+                                    <Label FontSize="10" Content="It seems that Thorg is unable to get your current account balance." Padding="0"/>
                                     <Label FontSize="10" Content="" Padding="0"/>
                                     <Label FontSize="10" Content="Please check if your Internet connection is working properly, if error persists try restarting Thorg." Padding="0"/>
                                     <Label FontSize="10" Content="" Padding="0"/>
-                                    <Label FontSize="10" Content="There might be a problem with connection to polygon gateway that returns your account's balance. " Padding="0"/>
+                                    <Label FontSize="10" Content="There might be a problem with connection to polygon gateway that returns your account balance. " Padding="0"/>
                                     <Label FontSize="10" Content="" Padding="0"/>
                                     <Label FontSize="10" Content="Good news is that you can still mine with Thorg! " Padding="0"/>
                                     <Label FontSize="10" Content="" Padding="0"/>
-                                    <Label FontSize="10" Content="Your balance should appear here later, once polygon gateway is reachable again. " Padding="0"/>
+                                    <Label FontSize="10" Content="Thorg will refresh your account balance once polygon gateway is reachable again. " Padding="0"/>
                                     <Label FontSize="10" Content="" Padding="0"/>
-                                    <Label FontSize="10" Content="If you would like to check your balance now, you can do it with polygonscan by following this link: " Padding="0"/>
+                                    <Label FontSize="10" Content="If you would like to check your account balance now, you can do it with polygonscan by following this link: " Padding="0"/>
                                     <TextBlock TextDecorations="Underline" >
                     <Hyperlink Foreground="white" NavigateUri="{Binding PolygonLink}" Click="Hyperlink_Click">
                         <TextBlock FontSize="10" Text="{Binding PolygonLink}" />

--- a/UI/DashboardMain.xaml
+++ b/UI/DashboardMain.xaml
@@ -100,13 +100,13 @@
                                 <StackPanel Margin="4">
                                     <Label FontSize="10" Content="It seems that Thorg is unable to get your current account balance." Padding="0"/>
                                     <Label FontSize="10" Content="" Padding="0"/>
-                                    <Label FontSize="10" Content="Please check if your Internet connection is working properly, if error persists try restarting Thorg." Padding="0"/>
+                                    <Label FontSize="10" Content="Please check if your Internet connection is working properly, if this error persists try restarting Thorg." Padding="0"/>
                                     <Label FontSize="10" Content="" Padding="0"/>
-                                    <Label FontSize="10" Content="There might be a problem with connection to polygon gateway that returns your account balance. " Padding="0"/>
+                                    <Label FontSize="10" Content="There might be a problem with your connection to the Polygon gateway that returns your account balance. " Padding="0"/>
                                     <Label FontSize="10" Content="" Padding="0"/>
                                     <Label FontSize="10" Content="Good news is that you can still mine with Thorg! " Padding="0"/>
                                     <Label FontSize="10" Content="" Padding="0"/>
-                                    <Label FontSize="10" Content="Thorg will refresh your account balance once polygon gateway is reachable again. " Padding="0"/>
+                                    <Label FontSize="10" Content="Thorg will refresh your account balance once the Polygon gateway is reachable again. " Padding="0"/>
                                     <Label FontSize="10" Content="" Padding="0"/>
                                     <Label FontSize="10" Content="If you would like to check your account balance now, you can do it with polygonscan by following this link: " Padding="0"/>
                                     <TextBlock TextDecorations="Underline" >

--- a/UI/DashboardMain.xaml.cs
+++ b/UI/DashboardMain.xaml.cs
@@ -62,5 +62,21 @@ namespace GolemUI
         {
             Model.SwitchToStatistics();
         }
+
+        private void lblPaymentStateMessage_MouseEnter(object sender, MouseEventArgs e)
+        {
+            if (Model.ShouldPaymentMessageTooltipBeAccessible)
+                tooltip.IsOpen = true;
+        }
+
+        private void lblPaymentStateMessage_MouseLeave(object sender, MouseEventArgs e)
+        {
+            tooltip.IsOpen = false;
+        }
+
+        private void Hyperlink_Click(object sender, RoutedEventArgs e)
+        {
+            System.Diagnostics.Process.Start(Model.PolygonLink);
+        }
     }
 }

--- a/ViewModel/DashboardMainViewModel.cs
+++ b/ViewModel/DashboardMainViewModel.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using GolemUI.Miners;
+using System;
 
 namespace GolemUI.ViewModel
 {
@@ -43,6 +44,35 @@ namespace GolemUI.ViewModel
 
             _benchmarkService.PropertyChanged += _benchmarkService_PropertyChanged;
             _taskProfitEstimator.PropertyChanged += _taskProfitEstimator_PropertyChanged;
+        }
+
+        public string PolygonLink => "https://polygonscan.com/token/0x0b220b82f3ea3b7f6d9a1d8ab58930c064a2b5bf?a=" + _paymentService.Address;
+        public bool ShouldPaymentMessageTooltipBeAccessible
+        {
+            get
+            {
+                if (_paymentService == null || (_paymentService?.LastError != null && _paymentService?.LastSuccessfullRefresh == null)) return true;
+                if (_paymentService?.LastSuccessfullRefresh != null)
+                {
+                    TimeSpan timeDiff = (DateTime.Now - (DateTime)_paymentService!.LastSuccessfullRefresh);
+                    if (timeDiff.TotalSeconds > 60 * 5)
+                        return true;
+                }
+                return false;
+
+            }
+        }
+        public string? PaymentStateMessage
+        {
+            get
+            {
+
+                if (_paymentService.LastError == null) return "";
+                if (_paymentService.LastSuccessfullRefresh == null) return "Unable to refresh account's balance";
+
+
+                return "last update: " + _paymentService.LastSuccessfullRefresh?.ToShortTimeString();
+            }
         }
 
         public void ChangeWindowState(MainWindowState state)
@@ -322,11 +352,17 @@ namespace GolemUI.ViewModel
 
         private void OnPaymentServiceChanged(object? sender, PropertyChangedEventArgs e)
         {
+            if (_paymentService?.State?.Balance != null)
+                _lastAmount = _paymentService?.State?.Balance;
+
             OnPropertyChanged("Amount");
             OnPropertyChanged("AmountUSD");
             OnPropertyChanged("PendingAmount");
             OnPropertyChanged("PendingAmountUSD");
-            OnPropertyChanged("PaymentStateError");
+            OnPropertyChanged("PaymentStateMessage");
+
+            if (e.PropertyName == "Address")
+                OnPropertyChanged(nameof(PolygonLink));
         }
 
         public void LoadData()
@@ -379,8 +415,10 @@ namespace GolemUI.ViewModel
         public event PageChangeRequestedEvent? PageChangeRequested;
 
         public IProcessController Process => _processController;
-        public decimal? Amount => _paymentService.State?.Balance;
-        public string? PaymentStateError => _paymentService.LastError;
+
+        private decimal? _lastAmount = null;
+        public decimal? Amount => _paymentService.State?.Balance ?? _lastAmount;
+
 
         private decimal? _usdPerDay = null;
         public decimal? UsdPerDay


### PR DESCRIPTION
If app fails to download balance on startup "Unable to refresh account's balance" blue text appears with tooltip Popup describing what todo

If app will manage to download this balance later "Unable to refresh account's balance" will disappear

If app will fail to download balance later on "last update: HH:MM" text will appear.

If app will fail to download balance for 5 minutes in a row beforementioned Popup tooltip will be appearing on MouseHover over "last update"

corrected tooltip text:
![image](https://user-images.githubusercontent.com/22456155/141508075-17eaee35-2925-4494-acaf-4539d5c7e46c.png)

![image](https://user-images.githubusercontent.com/22456155/141503517-f86d6c6a-0f87-4d44-86a0-cd64be4ad8d6.png)

![image](https://user-images.githubusercontent.com/22456155/141503534-f4d724cd-041a-4451-9ae5-3a581557b3f5.png)

![image](https://user-images.githubusercontent.com/22456155/141503960-8e165fb4-b09b-4d69-b3d2-b50408679d87.png)
